### PR TITLE
Add text selection and quote feature

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -176,3 +176,16 @@
   animation: fadeIn 0.2s ease-out;
 }
 
+/* Highlighted text styles */
+.highlighted-text {
+  background-color: rgba(231, 76, 60, 0.2); /* Reddish orange with transparency */
+  border-radius: 2px;
+  padding: 2px 0;
+  position: relative;
+}
+
+/* For dark mode */
+.dark .highlighted-text {
+  background-color: rgba(231, 76, 60, 0.3); /* Slightly more opaque for dark mode */
+}
+

--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -140,3 +140,39 @@
   transform: translateY(-2px);
 }
 
+/* Text selection styles */
+.text-selection-active {
+  position: relative;
+}
+
+.text-selection-quote {
+  position: absolute;
+  z-index: 50;
+  background-color: hsl(var(--secondary));
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 0.25rem;
+  transition: opacity 0.2s ease-in-out;
+}
+
+/* Ensure the quote icon is visible on all backgrounds */
+.text-selection-quote svg {
+  color: hsl(var(--foreground));
+}
+
+/* Add a subtle animation when the quote appears */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.text-selection-quote {
+  animation: fadeIn 0.2s ease-out;
+}
+

--- a/components/messages/message-codeblock.tsx
+++ b/components/messages/message-codeblock.tsx
@@ -58,6 +58,7 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
 
     const [selectedText, setSelectedText] = useState<string>("");
     const [selectionPosition, setSelectionPosition] = useState<{ x: number; y: number } | null>(null);
+    const [highlightedElement, setHighlightedElement] = useState<HTMLElement | null>(null);
     const codeBlockRef = useRef<HTMLDivElement>(null);
 
     const downloadAsFile = () => {
@@ -92,6 +93,21 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
       copyToClipboard(value)
     }
 
+    // Function to remove any existing highlights
+    const removeHighlights = () => {
+      if (highlightedElement) {
+        highlightedElement.classList.remove('highlighted-text');
+        setHighlightedElement(null);
+      }
+    };
+
+    // Function to clear the selection
+    const clearSelection = () => {
+      setSelectedText("");
+      setSelectionPosition(null);
+      removeHighlights();
+    };
+
     const handleTextSelection = () => {
       const selection = window.getSelection();
       if (selection && selection.toString().trim().length > 0) {
@@ -102,18 +118,47 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
         const text = selection.toString().trim();
         setSelectedText(text);
 
-        // Calculate position for the quote icon
-        if (codeBlockRef.current) {
-          const containerRect = codeBlockRef.current.getBoundingClientRect();
-          setSelectionPosition({
-            x: rect.left - containerRect.left + rect.width / 2,
-            y: rect.top - containerRect.top
-          });
+        // For code blocks, we'll highlight the parent element of the selection
+        // since we can't easily wrap the selection in a span due to the syntax highlighting
+        let currentNode = range.startContainer;
+
+        // Find the closest element node
+        while (currentNode.nodeType !== Node.ELEMENT_NODE && currentNode.parentElement) {
+          currentNode = currentNode.parentElement;
+        }
+
+        // Remove any existing highlights
+        removeHighlights();
+
+        // Add highlight class to the element
+        if (currentNode.nodeType === Node.ELEMENT_NODE) {
+          const element = currentNode as HTMLElement;
+          element.classList.add('highlighted-text');
+          setHighlightedElement(element);
+
+          // Calculate position for the quote icon - top right corner
+          if (codeBlockRef.current) {
+            const containerRect = codeBlockRef.current.getBoundingClientRect();
+            const elementRect = element.getBoundingClientRect();
+
+            setSelectionPosition({
+              x: elementRect.right - containerRect.left - 10, // 10px offset from right edge
+              y: elementRect.top - containerRect.top - 5 // 5px above the top
+            });
+          }
+        } else {
+          // Fallback if we can't find an element to highlight
+          if (codeBlockRef.current) {
+            const containerRect = codeBlockRef.current.getBoundingClientRect();
+            setSelectionPosition({
+              x: rect.right - containerRect.left - 10,
+              y: rect.top - containerRect.top - 5
+            });
+          }
         }
       } else {
         // Clear selection when nothing is selected
-        setSelectedText("");
-        setSelectionPosition(null);
+        clearSelection();
       }
     };
 
@@ -121,14 +166,20 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
     useEffect(() => {
       const handleClickOutside = (e: MouseEvent) => {
         if (codeBlockRef.current && !codeBlockRef.current.contains(e.target as Node)) {
-          setSelectedText("");
-          setSelectionPosition(null);
+          clearSelection();
         }
       };
 
       document.addEventListener("mousedown", handleClickOutside);
       return () => {
         document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, []);
+
+    // Clean up highlights when component unmounts
+    useEffect(() => {
+      return () => {
+        removeHighlights();
       };
     }, []);
 
@@ -142,8 +193,7 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
         }
         return quotedText;
       });
-      setSelectedText("");
-      setSelectionPosition(null);
+      clearSelection();
     };
 
     return (

--- a/components/messages/message-codeblock.tsx
+++ b/components/messages/message-codeblock.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@/components/ui/button"
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard"
-import { IconCheck, IconCopy, IconDownload } from "@tabler/icons-react"
-import { FC, memo } from "react"
+import { IconCheck, IconCopy, IconDownload, IconQuote } from "@tabler/icons-react"
+import { FC, memo, useRef, useState, useEffect, useContext } from "react"
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism"
+import { WithTooltip } from "../ui/with-tooltip"
+import { ChatbotUIContext } from "@/context/context"
 
 interface MessageCodeBlockProps {
   language: string
@@ -52,6 +54,11 @@ export const generateRandomString = (length: number, lowercase = false) => {
 export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
   ({ language, value }) => {
     const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
+    const { userInput, setUserInput } = useContext(ChatbotUIContext)
+
+    const [selectedText, setSelectedText] = useState<string>("");
+    const [selectionPosition, setSelectionPosition] = useState<{ x: number; y: number } | null>(null);
+    const codeBlockRef = useRef<HTMLDivElement>(null);
 
     const downloadAsFile = () => {
       if (typeof window === "undefined") {
@@ -85,8 +92,62 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
       copyToClipboard(value)
     }
 
+    const handleTextSelection = () => {
+      const selection = window.getSelection();
+      if (selection && selection.toString().trim().length > 0) {
+        const range = selection.getRangeAt(0);
+        const rect = range.getBoundingClientRect();
+
+        // Get the selected text
+        const text = selection.toString().trim();
+        setSelectedText(text);
+
+        // Calculate position for the quote icon
+        if (codeBlockRef.current) {
+          const containerRect = codeBlockRef.current.getBoundingClientRect();
+          setSelectionPosition({
+            x: rect.left - containerRect.left + rect.width / 2,
+            y: rect.top - containerRect.top
+          });
+        }
+      } else {
+        // Clear selection when nothing is selected
+        setSelectedText("");
+        setSelectionPosition(null);
+      }
+    };
+
+    // Clear selection when clicking outside
+    useEffect(() => {
+      const handleClickOutside = (e: MouseEvent) => {
+        if (codeBlockRef.current && !codeBlockRef.current.contains(e.target as Node)) {
+          setSelectedText("");
+          setSelectionPosition(null);
+        }
+      };
+
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, []);
+
+    const handleQuoteClick = () => {
+      // Add the selected text as a code block to the user input
+      const quotedText = `\`\`\`${language}\n${selectedText}\n\`\`\`\n\n`;
+      setUserInput(prevInput => {
+        // If there's already content, add a newline before adding the quote
+        if (prevInput.trim()) {
+          return `${prevInput}\n\n${quotedText}`;
+        }
+        return quotedText;
+      });
+      setSelectedText("");
+      setSelectionPosition(null);
+    };
+
     return (
-      <div className="codeblock relative w-full bg-zinc-950 font-sans">
+      <div className="codeblock text-selection-active relative w-full bg-zinc-950 font-sans" ref={codeBlockRef} onMouseUp={handleTextSelection}>
         <div className="flex w-full items-center justify-between bg-zinc-700 px-4 text-white">
           <span className="text-xs lowercase">{language}</span>
           <div className="flex items-center space-x-1">
@@ -109,6 +170,28 @@ export const MessageCodeBlock: FC<MessageCodeBlockProps> = memo(
             </Button>
           </div>
         </div>
+        {selectedText && selectionPosition && (
+          <div
+            className="text-selection-quote"
+            style={{
+              left: `${selectionPosition.x}px`,
+              top: `${selectionPosition.y - 40}px`
+            }}
+          >
+            <WithTooltip
+              delayDuration={500}
+              side="top"
+              display={<div>Quote selected code</div>}
+              trigger={
+                <IconQuote
+                  className="cursor-pointer hover:opacity-50"
+                  size={16}
+                  onClick={handleQuoteClick}
+                />
+              }
+            />
+          </div>
+        )}
         <SyntaxHighlighter
           language={language}
           style={oneDark}

--- a/components/messages/message-markdown.tsx
+++ b/components/messages/message-markdown.tsx
@@ -1,9 +1,10 @@
-import React, { FC } from "react"
+import React, { FC, useRef, useState, useEffect } from "react"
 import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
 import { MessageCodeBlock } from "./message-codeblock"
 import { MessageMarkdownMemoized } from "./message-markdown-memoized"
 import rehypeKatex from "rehype-katex"
+import { TextSelectionQuote } from "./text-selection-quote"
 
 interface MessageMarkdownProps {
   content: string
@@ -18,12 +19,67 @@ const replaceMathDelimiters = (content: string) => {
 }
 
 export const MessageMarkdown: FC<MessageMarkdownProps> = ({ content }) => {
+  const [selectedText, setSelectedText] = useState<string>("");
+  const [selectionPosition, setSelectionPosition] = useState<{ x: number; y: number } | null>(null);
+  const markdownRef = useRef<HTMLDivElement>(null);
+
+  const handleTextSelection = () => {
+    const selection = window.getSelection();
+    if (selection && selection.toString().trim().length > 0) {
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      // Get the selected text
+      const text = selection.toString().trim();
+      setSelectedText(text);
+
+      // Calculate position for the quote icon
+      if (markdownRef.current) {
+        const containerRect = markdownRef.current.getBoundingClientRect();
+        setSelectionPosition({
+          x: rect.left - containerRect.left + rect.width / 2,
+          y: rect.top - containerRect.top
+        });
+      }
+    } else {
+      // Clear selection when nothing is selected
+      setSelectedText("");
+      setSelectionPosition(null);
+    }
+  };
+
+  // Clear selection when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (markdownRef.current && !markdownRef.current.contains(e.target as Node)) {
+        setSelectedText("");
+        setSelectionPosition(null);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
   return (
-    <MessageMarkdownMemoized
-      className="prose dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 min-w-full space-y-6 break-words"
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
-      components={{
+    <div ref={markdownRef} className="text-selection-active relative" onMouseUp={handleTextSelection}>
+      {selectedText && selectionPosition && (
+        <TextSelectionQuote
+          selectedText={selectedText}
+          position={selectionPosition}
+          onClose={() => {
+            setSelectedText("");
+            setSelectionPosition(null);
+          }}
+        />
+      )}
+      <MessageMarkdownMemoized
+        className="prose dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 min-w-full space-y-6 break-words"
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
         p({ children }) {
           return <p className="mb-2 last:mb-0">{children}</p>
         },
@@ -75,5 +131,6 @@ export const MessageMarkdown: FC<MessageMarkdownProps> = ({ content }) => {
     >
       {replaceMathDelimiters(content)}
     </MessageMarkdownMemoized>
+    </div>
   )
 }

--- a/components/messages/message-markdown.tsx
+++ b/components/messages/message-markdown.tsx
@@ -21,7 +21,45 @@ const replaceMathDelimiters = (content: string) => {
 export const MessageMarkdown: FC<MessageMarkdownProps> = ({ content }) => {
   const [selectedText, setSelectedText] = useState<string>("");
   const [selectionPosition, setSelectionPosition] = useState<{ x: number; y: number } | null>(null);
+  const [selectedRange, setSelectedRange] = useState<Range | null>(null);
   const markdownRef = useRef<HTMLDivElement>(null);
+
+  // Function to highlight the selected text
+  const highlightSelectedText = (range: Range) => {
+    // Remove any existing highlights first
+    removeHighlights();
+
+    // Create a span element with the highlight class
+    const highlightSpan = document.createElement('span');
+    highlightSpan.className = 'highlighted-text';
+
+    // Wrap the selected text in the highlight span
+    try {
+      range.surroundContents(highlightSpan);
+      return highlightSpan;
+    } catch (e) {
+      console.error('Could not highlight text:', e);
+      return null;
+    }
+  };
+
+  // Function to remove all highlights
+  const removeHighlights = () => {
+    if (markdownRef.current) {
+      const highlights = markdownRef.current.querySelectorAll('.highlighted-text');
+      highlights.forEach(highlight => {
+        const parent = highlight.parentNode;
+        if (parent) {
+          // Move all children out of the highlight span
+          while (highlight.firstChild) {
+            parent.insertBefore(highlight.firstChild, highlight);
+          }
+          // Remove the empty highlight span
+          parent.removeChild(highlight);
+        }
+      });
+    }
+  };
 
   const handleTextSelection = () => {
     const selection = window.getSelection();
@@ -32,34 +70,59 @@ export const MessageMarkdown: FC<MessageMarkdownProps> = ({ content }) => {
       // Get the selected text
       const text = selection.toString().trim();
       setSelectedText(text);
+      setSelectedRange(range.cloneRange()); // Store the range for highlighting
 
-      // Calculate position for the quote icon
-      if (markdownRef.current) {
+      // Highlight the selected text
+      const highlightedElement = highlightSelectedText(range.cloneRange());
+
+      // Calculate position for the quote icon - top right corner of the selection
+      if (markdownRef.current && highlightedElement) {
+        const containerRect = markdownRef.current.getBoundingClientRect();
+        const highlightRect = highlightedElement.getBoundingClientRect();
+
+        setSelectionPosition({
+          x: highlightRect.right - containerRect.left - 10, // 10px offset from right edge
+          y: highlightRect.top - containerRect.top - 5 // 5px above the top
+        });
+      } else if (markdownRef.current) {
+        // Fallback if highlighting fails
         const containerRect = markdownRef.current.getBoundingClientRect();
         setSelectionPosition({
-          x: rect.left - containerRect.left + rect.width / 2,
-          y: rect.top - containerRect.top
+          x: rect.right - containerRect.left - 10,
+          y: rect.top - containerRect.top - 5
         });
       }
     } else {
       // Clear selection when nothing is selected
-      setSelectedText("");
-      setSelectionPosition(null);
+      clearSelection();
     }
+  };
+
+  const clearSelection = () => {
+    setSelectedText("");
+    setSelectionPosition(null);
+    setSelectedRange(null);
+    removeHighlights();
   };
 
   // Clear selection when clicking outside
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (markdownRef.current && !markdownRef.current.contains(e.target as Node)) {
-        setSelectedText("");
-        setSelectionPosition(null);
+        clearSelection();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  // Clean up highlights when component unmounts
+  useEffect(() => {
+    return () => {
+      removeHighlights();
     };
   }, []);
 
@@ -70,8 +133,7 @@ export const MessageMarkdown: FC<MessageMarkdownProps> = ({ content }) => {
           selectedText={selectedText}
           position={selectionPosition}
           onClose={() => {
-            setSelectedText("");
-            setSelectionPosition(null);
+            clearSelection();
           }}
         />
       )}

--- a/components/messages/text-selection-quote.tsx
+++ b/components/messages/text-selection-quote.tsx
@@ -1,0 +1,55 @@
+import { IconQuote } from "@tabler/icons-react"
+import { FC, useContext } from "react"
+import { WithTooltip } from "../ui/with-tooltip"
+import { ChatbotUIContext } from "@/context/context"
+import { MESSAGE_ICON_SIZE } from "./message-actions"
+
+interface TextSelectionQuoteProps {
+  selectedText: string
+  position: { x: number; y: number }
+  onClose: () => void
+}
+
+export const TextSelectionQuote: FC<TextSelectionQuoteProps> = ({
+  selectedText,
+  position,
+  onClose
+}) => {
+  const { userInput, setUserInput } = useContext(ChatbotUIContext)
+
+  const handleQuoteClick = () => {
+    // Add the selected text as a quote to the user input
+    const quotedText = `> ${selectedText}\n\n`
+    setUserInput(prevInput => {
+      // If there's already content, add a newline before adding the quote
+      if (prevInput.trim()) {
+        return `${prevInput}\n\n${quotedText}`
+      }
+      return quotedText
+    })
+    onClose()
+  }
+
+  return (
+    <div
+      className="text-selection-quote"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y - 40}px`
+      }}
+    >
+      <WithTooltip
+        delayDuration={500}
+        side="top"
+        display={<div>Quote selected text</div>}
+        trigger={
+          <IconQuote
+            className="cursor-pointer hover:opacity-50"
+            size={MESSAGE_ICON_SIZE}
+            onClick={handleQuoteClick}
+          />
+        }
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Feature Description

This PR adds a new feature that allows users to select specific parts of a message and have an icon appear which could look like double quotes. When the user clicks on this icon, the selected text gets automatically referenced in the chat input.

### Implementation Details

1. Created a `TextSelectionQuote` component that displays a quote icon when text is selected
2. Modified the `MessageMarkdown` component to handle text selection events and show the quote icon
3. Added functionality to insert the selected text into the chat input
4. Added support for code blocks in the `MessageCodeBlock` component
5. Added CSS styles for the text selection feature
6. Added reddish-orange highlighting for selected text
7. Positioned the quote icon at the top right corner of the selected text

### How It Works

1. When a user selects text in a message:
   - The selection is detected by the `onMouseUp` event
   - The selected text is stored in state and highlighted with a reddish-orange background
   - A quote icon appears at the top right corner of the selected text

2. When the user clicks the quote icon:
   - For regular text: The selected text is added to the chat input as a Markdown quote (prefixed with `>`)
   - For code blocks: The selected text is added to the chat input as a Markdown code block with the appropriate language

3. The quote icon and highlighting disappear when:
   - The user clicks outside the selection
   - The user clicks the quote icon (after the text is added to the input)

### Benefits

- Saves time by eliminating the need to manually copy and paste text
- Formats the referenced text appropriately based on its context (regular text vs. code)
- Enhances the user experience by making it easier to reference specific parts of an AI's response
- Visual highlighting makes it clear which text is being referenced